### PR TITLE
sail.md: Adding alt snippet for the "Configuring A Shell Alias Section

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -115,6 +115,14 @@ alias sail='sh $([ -f sail ] && echo sail || echo vendor/bin/sail)'
 
 To make sure this is always available, you may add this to your shell configuration file in your home directory, such as `~/.zshrc` or `~/.bashrc`, and then restart your shell.
 
+> [!TIP]  
+> Alternatively, you may wish to configure your shell alias (IE: on Intel MacOS machines) using your machine's `$PATH` list and a global composer instance, which looks more like this:
+> ```shell
+> # ~/.zshrc
+> export PATH="$PATH:$HOME/.composer/vendor/bin"
+> alias -g sail='bash vendor/bin/sail'
+> ```
+
 Once the shell alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:
 
 ```shell


### PR DESCRIPTION
Ok, so I was trying to install a new instance on a staff machine (Intel MacOS machine) and the existing alias snippet was hanging the machine. Not sure why tbh.

The fix was easy after bringing in the two lines of code from my own dev machine's `.zshrc` file. With that change, everything worked as expected.

Now granted, exactly why the original snippet didn't work is beyond me for now. But I figured I'd suggest this snippet that did work flawlessly anyway, because getting hung up on installs is a general bummer for any of us to hit in a work day.

If this is unneeded or only applicable to my code base or machines for some reason - please disregard this update and PR. On the other hand, if it's useful and/or if it needs some work to be helpful and/or included - please let me know!

Cheers and thank you for all the hard work!